### PR TITLE
Made launcher single use

### DIFF
--- a/Defs/Ammo/Advanced/Bullet_BoomRocket.xml
+++ b/Defs/Ammo/Advanced/Bullet_BoomRocket.xml
@@ -26,10 +26,6 @@
 	  <Mass>0.01</Mass>
 	  <Bulk>0.02</Bulk>
     </statBases>
-    <tradeTags>
-      <li>CE_AutoEnableTrade</li>
-      <li>CE_AutoEnableCrafting</li>
-    </tradeTags>
     <thingCategories>
       <li>AmmoBoomRocket</li>
     </thingCategories>

--- a/Patches/ThingDefs_Misc/Weapons_Callistan.xml
+++ b/Patches/ThingDefs_Misc/Weapons_Callistan.xml
@@ -166,7 +166,7 @@
     </statBases>
     <Properties>
 		<recoilAmount>0.60</recoilAmount>
-      <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+      <verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
       <hasStandardCommand>true</hasStandardCommand>
       <defaultProjectile>Bullet_BoomRocket</defaultProjectile>
       <warmupTime>9</warmupTime>


### PR DESCRIPTION
CE was throwing a red error about not finding a recipe for the boom rocket as it was marked autoenable_crafting; removed that tag + trade tag and made weapon single use